### PR TITLE
Adding ability to override default metalsmith-eslint options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+test/fixtures/browser/build

--- a/README.md
+++ b/README.md
@@ -35,4 +35,12 @@ metalsmith.use(xo('esnext'));
 metalsmith.use(xo('browser'));
 ```
 
+**Custom metalsmith-eslint config**
+```js
+var config = {
+	src: ['**/*.js','!vendor/**/*.js']
+}
+metalsmith.use(xo('browser', config));
+```
+
 You can pass `esnext` or `browser` to the function to turn on the rules you need. However, `esnext` requires some extra modules that you can read [over there](https://github.com/sindresorhus/eslint-config-xo).

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,19 @@
-var eslint = require('metalsmith-eslint');
+var eslint    = require('metalsmith-eslint');
+var _defaults = require('lodash.defaults');
 
-module.exports = function (sub) {
-	return eslint({
+module.exports = function (sub, config) {
+	config = config || {};
+	config = _defaults(config, getDefaults(sub));
+	return eslint(config);
+};
+
+function getDefaults(sub) {
+	return {
 		eslintConfig: {
 			useEslintrc: false,
-			baseConfig: {extends: 'xo' + ((sub === 'esnext' || sub === 'browser') ? '/' + sub : '')}
+			baseConfig: {
+				extends: 'xo' + ((sub === 'esnext' || sub === 'browser') ? '/' + sub : '')
+			}
 		}
-	});
-};
+	};
+}

--- a/package.json
+++ b/package.json
@@ -9,16 +9,17 @@
   },
   "author": "Blain Smith <rebelgeek@blainsmith.com> (http://blainsmith.com/)",
   "license": "MIT",
-	"repository": "blainsmith/metalsmith-xo",
+  "repository": "blainsmith/metalsmith-xo",
   "keywords": [
     "metalsmith",
     "eslint",
     "linting",
-		"xo"
+    "xo"
   ],
   "dependencies": {
     "eslint": "^1.7.1",
     "eslint-config-xo": "^0.6.0",
+    "lodash.defaults": "^3.1.2",
     "metalsmith-eslint": "0.0.3"
   },
   "devDependencies": {

--- a/test/fixtures/browser/ok.js
+++ b/test/fixtures/browser/ok.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function ok(val) {
+	return (typeof val === Object);
+}
+
+ok('Hi');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,7 +19,7 @@ test.after(function (t) {
 test('xo', function (t) {
 	/* eslint-disable */
 	Metalsmith('./test/fixtures/xo')
-	/* eslint-ensable */
+	/* eslint-enable */
 		.source('./')
 		.use(xo())
 		.build(function (err) {
@@ -33,7 +33,7 @@ test('xo', function (t) {
 test('xo/esnext', function (t) {
 	/* eslint-disable */
 	Metalsmith('./test/fixtures/esnext')
-	/* eslint-ensable */
+	/* eslint-enable */
 		.source('./')
 		.use(xo('esnext'))
 		.build(function (err) {
@@ -47,9 +47,53 @@ test('xo/esnext', function (t) {
 test('xo/browser', function (t) {
 	/* eslint-disable */
 	Metalsmith('./test/fixtures/browser')
-	/* eslint-ensable */
+	/* eslint-enable */
 		.source('./')
 		.use(xo('browser'))
+		.build(function (err) {
+			t.ok(err, 'linting failed');
+			t.is(err.message, 'Linting failed with 1 errors!');
+			sinon.assert.calledWithExactly(console.log, '\n\u001b[4merror.js\u001b[24m\n  \u001b[90m1:16\u001b[39m  \u001b[31merror\u001b[39m  "require" is not defined  \u001b[90mno-undef\u001b[39m\n\n\u001b[31m\u001b[1m✖ 1 problem (1 error, 0 warnings)\n\u001b[22m\u001b[39m');
+			t.end();
+		});
+});
+
+test('xo/browser with good src config', function (t) {
+	/* eslint-disable */
+	Metalsmith('./test/fixtures/browser')
+	/* eslint-enable */
+		.source('./')
+		.use(xo('browser', {
+			src: ['ok.js','!error.js']
+		}))
+		.build(function (err) {
+			t.is(err, null);
+			t.end();
+		});
+});
+
+test('xo/browser with bad src config', function (t) {
+	/* eslint-disable */
+	Metalsmith('./test/fixtures/browser')
+	/* eslint-enable */
+		.source('./')
+		.use(xo('browser', {
+			src: ['*.js']
+		}))
+		.build(function (err) {
+			t.ok(err, 'linting failed');
+			t.is(err.message, 'Linting failed with 1 errors!');
+			sinon.assert.calledWithExactly(console.log, '\n\u001b[4merror.js\u001b[24m\n  \u001b[90m1:16\u001b[39m  \u001b[31merror\u001b[39m  "require" is not defined  \u001b[90mno-undef\u001b[39m\n\n\u001b[31m\u001b[1m✖ 1 problem (1 error, 0 warnings)\n\u001b[22m\u001b[39m');
+			t.end();
+		});
+});
+
+test('xo/browser with empty config', function (t) {
+	/* eslint-disable */
+	Metalsmith('./test/fixtures/browser')
+	/* eslint-enable */
+		.source('./')
+		.use(xo('browser', {}))
 		.build(function (err) {
 			t.ok(err, 'linting failed');
 			t.is(err.message, 'Linting failed with 1 errors!');


### PR DESCRIPTION
  * Add tests
  * Update README
  * Second param is object w/ any overrides of `metalsmith-eslint` options.